### PR TITLE
fix: move action version comments to inline format

### DIFF
--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -20,12 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        # v6.0.2 - https://github.com/actions/checkout/releases/tag/v6.0.2
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run hadolint
-        # v3.3.0 - https://github.com/hadolint/hadolint-action/releases/tag/v3.3.0
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
         with:
           dockerfile: "Dockerfile.*"
           failure-threshold: error

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,16 +11,13 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      # v6.0.2 - https://github.com/actions/checkout/releases/tag/v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      # v5.0.0 - https://github.com/actions/setup-node/releases/tag/v5.0.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24'
           cache: 'npm'
       - run: npm ci
-      # v1.34.0 - https://github.com/reviewdog/action-eslint/releases/tag/v1.34.0
-      - uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96
+      - uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/safe-chain.yml
+++ b/.github/workflows/safe-chain.yml
@@ -10,11 +10,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      # v6.0.2 - https://github.com/actions/checkout/releases/tag/v6.0.2
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js
-        # v5.0.0 - https://github.com/actions/setup-node/releases/tag/v5.0.0
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '24'
       - name: Setup safe-chain


### PR DESCRIPTION
## Summary
- Dependabot updates action SHAs but leaves version comments on separate lines stale (e.g. PR #124)
- Moved all version comments from the line above `uses:` to inline on the same line (`# vX.Y.Z`)
- This ensures Dependabot updates both the SHA and the version comment together

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Confirm all 7 `uses:` lines have inline version comments
- [ ] Confirm no stale version comment lines remain above `uses:` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)