### PR TITLE
feat(eslint): add consistent-type-imports and no-import-type-side-effects rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/
 chmod 755 docker-entrypoint.sh
 ```
 
-Detailed environment setup instructions are described at the beginning of the [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.2.0/Dockerfile.dev).
+Detailed environment setup instructions are described at the beginning of the [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.2.1/Dockerfile.dev).
 
 ## Production
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -103,6 +103,13 @@ export default defineConfig(
         },
       ],
 
+      // type-only import に副作用を持たせない
+      // import type { Foo } from '...' を import { type Foo } from '...' と書かせない
+      '@typescript-eslint/no-import-type-side-effects': 'error',
+
+      // type import は必ず import type を使う
+      '@typescript-eslint/consistent-type-imports': 'error',
+
       // 命名規則 (Google TypeScript Style Guide ベース)
       '@typescript-eslint/naming-convention': [
         'warn',


### PR DESCRIPTION
## Summary

- `@typescript-eslint/consistent-type-imports`: type importは必ず `import type` を使うよう強制
- `@typescript-eslint/no-import-type-side-effects`: `import { type Foo }` ではなく `import type { Foo }` の形式を強制し、type-only importに副作用を持たせない

## Test plan

- [ ] `npm run lint` がエラーなしで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)