### PR TITLE
feat: add AWS Toolkit extension and SAM/CloudFormation YAML settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,12 @@
 {
   "recommendations": [
     //
+    // AWS
+    //
+    // https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-toolkit-vscode
+    "AmazonWebServices.aws-toolkit-vscode",
+
+    //
     // Git & GitHub
     //
     // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,4 +59,43 @@
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true
   },
+
+  //
+  // AWS Toolkit
+  //
+  // ---------------------------------------------------------------------------
+  // YAML (redhat.vscode-yaml) を SAM / CloudFormation テンプレート向けに設定
+  // ---------------------------------------------------------------------------
+
+  // CloudFormation の組み込み関数ショートハンド (!Sub / !Ref / !GetAtt 等) を
+  // YAML パーサに「既知のタグ」として登録する。
+  // 未登録だと "Unresolved tag: !Sub" のような警告が出る。
+  // 同名タグでもスカラー値と配列値で別物扱いされるため、配列形式を使う関数は
+  // "!Xxx" と "!Xxx sequence" の両方を登録する。
+  "yaml.customTags": [
+    "!And", "!And sequence",
+    "!If", "!If sequence",
+    "!Not", "!Not sequence",
+    "!Equals", "!Equals sequence",
+    "!Or", "!Or sequence",
+    "!FindInMap", "!FindInMap sequence",
+    "!Base64", "!Cidr",
+    "!Ref", "!Sub", "!Sub sequence",
+    "!GetAtt", "!GetAZs",
+    "!ImportValue", "!ImportValue sequence",
+    "!Select", "!Select sequence",
+    "!Split", "!Split sequence",
+    "!Join", "!Join sequence",
+    "!Transform"
+  ],
+
+  // template.yaml / template.yml に SAM 公式スキーマを紐付ける。
+  // これにより AWS::Serverless::Function 配下の Runtime / Handler / CodeUri など
+  // のプロパティが補完・型検証される。
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/aws/serverless-application-model/main/samtranslator/schema/schema.json": [
+      "template.yaml",
+      "template.yml"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Add `AmazonWebServices.aws-toolkit-vscode` to recommended VSCode extensions
- Register CloudFormation intrinsic function shorthand tags (`!Sub`, `!Ref`, `!GetAtt`, etc.) in `yaml.customTags` to silence "Unresolved tag" warnings
- Bind the official SAM schema to `template.yaml` / `template.yml` for completion and validation of `AWS::Serverless::Function` properties

## Test plan
- [ ] Open the workspace in VSCode and confirm the AWS Toolkit recommendation prompt appears
- [ ] Open a `template.yaml` and verify CloudFormation intrinsic tags no longer trigger YAML warnings
- [ ] Verify SAM schema autocomplete works for `Runtime`, `Handler`, `CodeUri`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)