### PR TITLE
fix: update Dockerfile.dev links to version 1.3.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Please download the required files by following these steps:
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/Dockerfile.dev
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/Dockerfile.dev
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-Detailed environment setup instructions are described at the beginning of the [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.2.7/Dockerfile.dev).
+Detailed environment setup instructions are described at the beginning of the [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.3.0/Dockerfile.dev).
 
 ## Production
 


### PR DESCRIPTION
## Summary
- Bump `Dockerfile.dev` / `docker-entrypoint.sh` download URLs and the inline `Dockerfile.dev` link in README from `hello-javascript` tag `1.2.7` → `1.3.0`

## Test plan
- [ ] `curl -L -O` against the new 1.3.0 URLs returns 200 and the expected file contents
- [ ] `Dockerfile.dev` GitHub link in README resolves to the 1.3.0 ref

🤖 Generated with [Claude Code](https://claude.com/claude-code)