### PR TITLE
docs: Japanese README and hello-javascript 1.5.0 dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 .Trash-*
 __snapshots__
 docker-entrypoint.sh
-Dockerfile.dev
+Dockerfile.dev.docker
+Dockerfile.dev.container

--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
 ## 開発
 
+開発コンテナは macOS ホストでのみ動作確認されています。事前に GitHub の fine-grained PAT（[発行ページ](https://github.com/settings/personal-access-tokens/new)）を作成し、macOS Keychain に保存してください。必要な権限などの詳細は各 Dockerfile の冒頭を参照してください。
+
+```
+security add-generic-password -a "$USER" -s development-pat -w
+```
+
+### Docker を使う場合
+
 以下の手順で必要なファイルをダウンロードしてください。
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/Dockerfile.dev
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.0/Dockerfile.dev.docker
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.0/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.3.0/Dockerfile.dev) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.0/Dockerfile.dev.docker) の冒頭に記載されています。
+
+### Apple Container を使う場合
+
+macOS 26 以降（Apple Silicon）で利用できます。以下の手順で必要なファイルをダウンロードしてください。
+
+```
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.0/Dockerfile.dev.container
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.0/docker-entrypoint.sh
+chmod 755 docker-entrypoint.sh
+```
+
+環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.0/Dockerfile.dev.container) の冒頭に記載されています。
 
 ## 本番環境
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-## Development
+## 開発
 
-Please download the required files by following these steps:
+以下の手順で必要なファイルをダウンロードしてください。
 
 ```
 curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/Dockerfile.dev
@@ -8,8 +8,8 @@ curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/
 chmod 755 docker-entrypoint.sh
 ```
 
-Detailed environment setup instructions are described at the beginning of the [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.3.0/Dockerfile.dev).
+環境構築の詳細な手順は [Dockerfile.dev](https://github.com/uraitakahito/hello-javascript/blob/1.3.0/Dockerfile.dev) の冒頭に記載されています。
 
-## Production
+## 本番環境
 
-Build and run instructions are described at the beginning of the [Dockerfile.prod](Dockerfile.prod).
+ビルドと実行の手順は [Dockerfile.prod](Dockerfile.prod) の冒頭に記載されています。


### PR DESCRIPTION
## 概要
README をリファレンスとして実用に耐える形へ整えるドキュメント更新です。2 つのコミットを含みます。

## 変更内容
1. **README を日本語化** (`ebd44bb`)
   - 「開発 / 本番環境」セクションの説明文を日本語へ翻訳。コード・URL・リンクは原文のまま保持。

2. **開発手順を hello-javascript 1.5.0 へ更新** (`b637f4d`)
   - 1.5.0 で upstream の `Dockerfile.dev` が `Dockerfile.dev.docker`(Docker)と `Dockerfile.dev.container`(Apple Container)へ分割リネームされたことに追従。
   - 「開発」を Docker / Apple Container の 2 ランタイム構成に再編。
   - 1.4.0 以降必須となった fine-grained PAT(`GH_TOKEN`, macOS Keychain)の前提条件を追記。
   - `.gitignore` をリネーム後のダウンロード生成物に追従。

## 検証
- 新しい raw URL 3 種が HTTP 200、旧 `Dockerfile.dev` は 404 であることを確認。
- `git check-ignore` でダウンロード生成物が無視されることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbRp5x3b4D2x6vhda4zPsX