### PR TITLE
chore: add Dependabot cooldown and tidy dev-setup README

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
       day: monday
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    # Wait 7 days after a release before opening update PRs, so versions still
+    # too new for safe-chain's minimum-age check don't produce red PRs.
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
     groups:
@@ -25,6 +29,9 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Let a new base-image tag settle for 7 days before proposing it.
+    cooldown:
+      default-days: 7
     labels:
       - docker
 
@@ -36,6 +43,9 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Let a new action release settle for 7 days before proposing it.
+    cooldown:
+      default-days: 7
     labels:
       - ci
     groups:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 ## 開発
 
-開発コンテナは macOS ホストでのみ動作確認されています。事前に GitHub の fine-grained PAT（[発行ページ](https://github.com/settings/personal-access-tokens/new)）を作成し、macOS Keychain に保存してください。必要な権限などの詳細は各 Dockerfile の冒頭を参照してください。
-
-```
-security add-generic-password -a "$USER" -s development-pat -w
-```
+開発コンテナは macOS ホストでのみ動作確認されています。事前に GitHub の fine-grained PAT（[発行ページ](https://github.com/settings/personal-access-tokens/new)）を作成し、macOS Keychain に保存してください。詳細は各 Dockerfile の冒頭に記載されているコメントを参照してください。
 
 ### VS Code 設定のリンク（共通）
 
@@ -28,7 +24,7 @@ chmod 755 docker-entrypoint.sh
 
 環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.2/Dockerfile.dev.container) の冒頭に記載されています。
 
-### Docker を使う場合
+### Docker を使う場合(メンテナンス遅れがち)
 
 ```
 curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.2/Dockerfile.dev.docker


### PR DESCRIPTION
## 概要

develop に積んだ 2 件をまとめて main へ反映します。

## 変更

- **ci:** Dependabot に 7 日の `cooldown` を追加（npm / docker / github-actions）。
  公開直後の版を PR にしないことで、safe-chain の minimum package age に弾かれる
  「赤い CI の更新 PR」（例: #153）を未然に防ぎます。セキュリティ更新は cooldown の
  対象外なので、脆弱性パッチは従来どおり即時に PR されます。 (`2368290`)
- **docs:** 開発セットアップの README を整理。PAT 設定手順を各 Dockerfile 冒頭コメントへの
  誘導に集約し、`security add-generic-password` のスニペットを削除。Docker 節の見出しに
  「(メンテナンス遅れがち)」の注記を追加。 (`8b1f0ad`)

## 影響範囲

- `.github/dependabot.yml`、`README.md` のみ。アプリのコード・依存・ビルドには影響なし。
