### PR TITLE
docs: bump hello-javascript config script links 1.5.3 → 1.5.5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `.vscode/` 配下の各 `*.sample.jsonc` から、`sample` を除いた名前のシンボリックリンク（例: `launch.json → launch.sample.jsonc`）を生成します。スクリプトは上流から取得します（コンテナ方式に依らず共通の初回作業です）。
 
 ```
-curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/.vscode/link-vscode-config.sh
+curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/.vscode/link-vscode-config.sh
 chmod 755 .vscode/link-vscode-config.sh
 .vscode/link-vscode-config.sh
 ```
@@ -17,20 +17,20 @@ chmod 755 .vscode/link-vscode-config.sh
 macOS 26 以降（Apple Silicon）で利用できます。
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/Dockerfile.dev.container
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/Dockerfile.dev.container
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.4/Dockerfile.dev.container) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.5/Dockerfile.dev.container) の冒頭に記載されています。
 
 ### Docker を使う場合(メンテナンス遅れがち)
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/Dockerfile.dev.docker
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/Dockerfile.dev.docker
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.4/Dockerfile.dev.docker) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.5/Dockerfile.dev.docker) の冒頭に記載されています。
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `.vscode/` 配下の各 `*.sample.jsonc` から、`sample` を除いた名前のシンボリックリンク（例: `launch.json → launch.sample.jsonc`）を生成します。スクリプトは上流から取得します（コンテナ方式に依らず共通の初回作業です）。
 
 ```
-curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.3/.vscode/link-vscode-config.sh
+curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/.vscode/link-vscode-config.sh
 chmod 755 .vscode/link-vscode-config.sh
 .vscode/link-vscode-config.sh
 ```
@@ -17,20 +17,20 @@ chmod 755 .vscode/link-vscode-config.sh
 macOS 26 以降（Apple Silicon）で利用できます。
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.3/Dockerfile.dev.container
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.3/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/Dockerfile.dev.container
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.3/Dockerfile.dev.container) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.4/Dockerfile.dev.container) の冒頭に記載されています。
 
 ### Docker を使う場合(メンテナンス遅れがち)
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.3/Dockerfile.dev.docker
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.3/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/Dockerfile.dev.docker
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.4/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.3/Dockerfile.dev.docker) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.4/Dockerfile.dev.docker) の冒頭に記載されています。
 


### PR DESCRIPTION
## 概要

README の上流 **hello-javascript** 設定スクリプト参照を、タグ `1.5.3` → `1.5.5` に更新します。

## コミット

- `a7db9bb` docs: update links to version 1.5.4 in README.md for configuration scripts
- `0d978be` docs: update links to version 1.5.5 in README.md for configuration scripts

（中間の `1.5.4` を経て最終的に `1.5.5` へ。main から見た正味の差分は `1.5.3` → `1.5.5`）

## 変更内容

`README.md` の7箇所を更新（1 file changed, 7 insertions(+), 7 deletions(-)）:

- `curl` URL — `link-vscode-config.sh`
- `curl` URL — `Dockerfile.dev.container` / `docker-entrypoint.sh`（コンテナ方式）
- `curl` URL — `Dockerfile.dev.docker` / `docker-entrypoint.sh`（Docker方式）
- 手順リンク — `Dockerfile.dev.container` の冒頭コメントへのリンク
- 手順リンク — `Dockerfile.dev.docker` の冒頭コメントへのリンク

## 影響範囲

- ドキュメントのみ。ソースコード・ビルド・CI への影響なし。
- 新規環境構築時に、上流の最新タグ `1.5.5` のスクリプトを取得するようになります。
