### PR TITLE
docs: bump hello-javascript config script links 1.5.5 → 1.5.6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `.vscode/` 配下の各 `*.sample.jsonc` から、`sample` を除いた名前のシンボリックリンク（例: `launch.json → launch.sample.jsonc`）を生成します。スクリプトは上流から取得します（コンテナ方式に依らず共通の初回作業です）。
 
 ```
-curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/.vscode/link-vscode-config.sh
+curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/.vscode/link-vscode-config.sh
 chmod 755 .vscode/link-vscode-config.sh
 .vscode/link-vscode-config.sh
 ```
@@ -17,20 +17,20 @@ chmod 755 .vscode/link-vscode-config.sh
 macOS 26 以降（Apple Silicon）で利用できます。
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/Dockerfile.dev.container
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/Dockerfile.dev.container
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.5/Dockerfile.dev.container) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.6/Dockerfile.dev.container) の冒頭に記載されています。
 
 ### Docker を使う場合(メンテナンス遅れがち)
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/Dockerfile.dev.docker
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.5/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/Dockerfile.dev.docker
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.5/Dockerfile.dev.docker) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.6/Dockerfile.dev.docker) の冒頭に記載されています。
 


### PR DESCRIPTION
## 概要

README の開発環境セットアップ手順内で、上流 `hello-javascript` から取得する設定スクリプト類のバージョンリンクを **1.5.5 → 1.5.6** に更新します。ドキュメントのみの変更です。

## 変更点

`README.md` の以下のリンク先タグを 1.5.5 から 1.5.6 へ:

- `.vscode/link-vscode-config.sh` の取得 URL
- `Dockerfile.dev.container` / `docker-entrypoint.sh` の取得 URL と「詳細な手順」リンク
- `Dockerfile.dev.docker` / `docker-entrypoint.sh` の取得 URL と「詳細な手順」リンク

## 影響範囲

- ドキュメントのみ（コード・設定・CI への影響なし）
- 差分: `README.md` の 7 箇所（+7 / -7）

🤖 Generated with [Claude Code](https://claude.com/claude-code)