### PR TITLE
docs: update links to version 1.5.11 in README.md for configuration scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `.vscode/` 配下の各 `*.sample.jsonc` から、`sample` を除いた名前のシンボリックリンク（例: `launch.json → launch.sample.jsonc`）を生成します。スクリプトは上流から取得します（コンテナ方式に依らず共通の初回作業です）。
 
 ```
-curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/.vscode/link-vscode-config.sh
+curl -L -o .vscode/link-vscode-config.sh https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.11/.vscode/link-vscode-config.sh
 chmod 755 .vscode/link-vscode-config.sh
 .vscode/link-vscode-config.sh
 ```
@@ -17,20 +17,20 @@ chmod 755 .vscode/link-vscode-config.sh
 macOS 26 以降（Apple Silicon）で利用できます。
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/Dockerfile.dev.container
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.11/Dockerfile.dev.container
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.11/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.6/Dockerfile.dev.container) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.container](https://github.com/uraitakahito/hello-javascript/blob/1.5.11/Dockerfile.dev.container) の冒頭に記載されています。
 
 ### Docker を使う場合(メンテナンス遅れがち)
 
 ```
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/Dockerfile.dev.docker
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.6/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.11/Dockerfile.dev.docker
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.5.11/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 
-環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.6/Dockerfile.dev.docker) の冒頭に記載されています。
+環境構築の詳細な手順は [Dockerfile.dev.docker](https://github.com/uraitakahito/hello-javascript/blob/1.5.11/Dockerfile.dev.docker) の冒頭に記載されています。
 


### PR DESCRIPTION
Bumps the referenced **hello-javascript** tag from `1.5.6` to `1.5.11` in the setup instructions — the `curl`/`blob` URLs for `link-vscode-config.sh`, `Dockerfile.dev.container`, `Dockerfile.dev.docker`, and `docker-entrypoint.sh`.

hello-javascript `1.5.11` exists upstream (`7e6c68e`), so the links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)